### PR TITLE
feat: 쿠키에 토큰이 있으나 관리자권한이 없는 경우 로그인 화면으로 리다이렉트

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -25,7 +25,7 @@ function addRefreshSubscriber(cb: (token: string) => void) {
 
 // axios 인스턴스 생성
 const axiosInstance = axios.create({
-  baseURL: 'https://garlicbears.com/api',
+  baseURL: process.env.REACT_APP_API_URL,
   timeout: 5000,
   withCredentials: true,
 });

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -3,12 +3,29 @@ import axios, {
   AxiosResponse,
   InternalAxiosRequestConfig,
   AxiosHeaders,
+  AxiosRequestHeaders,
 } from 'axios';
 import Cookies from 'js-cookie';
 
+interface CustomAxiosRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
+let isRefreshing = false;
+let refreshSubscribers: ((token: string) => void)[] = [];
+
+function onRrefreshed(token: string) {
+  refreshSubscribers.map(cb => cb(token));
+  refreshSubscribers = [];
+}
+
+function addRefreshSubscriber(cb: (token: string) => void) {
+  refreshSubscribers.push(cb);
+}
+
 // axios 인스턴스 생성
 const axiosInstance = axios.create({
-  baseURL: process.env.REACT_APP_API_URL,
+  baseURL: 'https://garlicbears.com/api',
   timeout: 5000,
   withCredentials: true,
 });
@@ -24,10 +41,7 @@ axiosInstance.interceptors.request.use(
     const isExcludedUrl = excludeUrlEndings.some(ending =>
       config.url?.endsWith(ending),
     );
-    if (!accessToken && !isExcludedUrl) {
-      window.location.href = '/login'; // 로그인 페이지로 리디렉션
-      throw new AxiosError('No access token', '401');
-    }
+
     if (accessToken && !isExcludedUrl) {
       if (!config.headers) {
         config.headers = new AxiosHeaders();
@@ -46,32 +60,52 @@ axiosInstance.interceptors.response.use(
   (response: AxiosResponse): AxiosResponse => {
     return response;
   },
-  async (error: AxiosError): Promise<AxiosError> => {
-    // 에러코드 401이 발생하면 refresh token을 사용하여 accessToken을 갱신
-    if (error.response?.status === 401) {
-      try {
-        // refresh token을 사용하여 accessToken 갱신
-        const response = await axiosInstance.get('/admin/reissue');
-        const accessToken = response.headers['authorization'];
-        if (accessToken) {
-          Cookies.set('accessToken', accessToken, {
-            expires: 1,
-            secure: true,
-            sameSite: 'Strict',
-          });
+  async (error: AxiosError): Promise<any> => {
+    const originalRequest = error.config as CustomAxiosRequestConfig;
 
-          // 원래의 요청을 다시 시도
-          if (error.config) {
-            error.config.headers.set('Authorization', `Bearer ${accessToken}`);
-            return axiosInstance.request(error.config);
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (!isRefreshing) {
+        originalRequest._retry = true;
+        isRefreshing = true;
+
+        try {
+          const response = await axiosInstance.get('/admin/reissue');
+          const newAccessToken = response.headers['authorization'];
+
+          if (newAccessToken) {
+            Cookies.set('accessToken', newAccessToken, {
+              expires: 1,
+              secure: true,
+              sameSite: 'Strict',
+            });
+
+            isRefreshing = false;
+            onRrefreshed(newAccessToken);
+
+            (originalRequest.headers as AxiosRequestHeaders).Authorization =
+              `Bearer ${newAccessToken}`;
+            return axiosInstance(originalRequest);
           }
+        } catch (refreshError) {
+          isRefreshing = false;
+          refreshSubscribers = [];
+          Cookies.remove('accessToken');
+          window.location.href = `${process.env.PUBLIC_URL}/login`;
+          return Promise.reject(refreshError);
         }
-      } catch (refreshError) {
-        console.error('Error refreshing token:', refreshError);
-        // refresh token이 만료된 경우 로그인 페이지로 이동
-        Cookies.remove('accessToken');
-        window.location.href = '/login';
       }
+
+      const retryOriginalRequest = new Promise(resolve => {
+        addRefreshSubscriber((token: string) => {
+          (originalRequest.headers as AxiosRequestHeaders).Authorization =
+            `Bearer ${token}`;
+          resolve(axiosInstance(originalRequest));
+        });
+      });
+
+      return retryOriginalRequest;
+    } else if (error.response?.status === 403) {
+      window.location.href = `${process.env.PUBLIC_URL}/login`;
     }
     return Promise.reject(error);
   },

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -14,7 +14,7 @@ interface CustomAxiosRequestConfig extends InternalAxiosRequestConfig {
 let isRefreshing = false;
 let refreshSubscribers: ((token: string) => void)[] = [];
 
-function onRrefreshed(token: string) {
+function onRefreshed(token: string) {
   refreshSubscribers.map(cb => cb(token));
   refreshSubscribers = [];
 }
@@ -80,7 +80,7 @@ axiosInstance.interceptors.response.use(
             });
 
             isRefreshing = false;
-            onRrefreshed(newAccessToken);
+            onRefreshed(newAccessToken);
 
             (originalRequest.headers as AxiosRequestHeaders).Authorization =
               `Bearer ${newAccessToken}`;


### PR DESCRIPTION
1. accessToken 만료 시 reissue 한 번만 호출하는 코드 추가
2. 403 response status 반환 시 로그인 화면으로 이동
  - 기존 window.location.href = '/login' 시 {host}/login 으로 이동하여 404에러 발생
  - Router에서 basename으로 사용하는 변수를 추가하여 window.location.href = `{process.env.PUBLIC_URL}/login` 으로 수정